### PR TITLE
properly formatted date string in logging.ini

### DIFF
--- a/etc/logging.ini
+++ b/etc/logging.ini
@@ -8,11 +8,11 @@ keys=console,syslog
 keys=root
 
 [formatter_simple]
-format=eyepea :%(name)s:%(levelname)s:  %(message)s
+format=eyepea_ma:%(name)s:%(levelname)s:  %(message)s
 datefmt=%m/%d/%Y %I:%M:%S %p
 
 [formatter_detailed]
-format=eyepea:%(name)s:%(levelname)s %(module)s:%(lineno)d:  %(message)s
+format=eyepea_ma:%(name)s:%(levelname)s %(module)s:%(lineno)d:  %(message)s
 datefmt=%m/%d/%Y %I:%M:%S %p
 
 [handler_console]


### PR DESCRIPTION
I have modified the logging.ini to include the date that each command is processed, here is the format datefmt=%m/%d/%Y %I:%M:%S %p. Let me know if that is acceptable, I think it might be a good idea to daemonize the agent and possibly include multiprocessing. I still need to rewrite the requests calls, to use urllib2 if request is not available. Alot of the systems, that I need to monitor are rhel5 which does not have support for python-requests as its python version is still python 2.4. 
