### PR TITLE
update cron definition

### DIFF
--- a/etc/cron.d/tanto
+++ b/etc/cron.d/tanto
@@ -1,2 +1,2 @@
 MAILTO=""
-* * * * * root /usr/bin/env tanto &> /dev/null
+* * * * * root /usr/bin/env tanto > /dev/null 2>&1


### PR DESCRIPTION
do not assume /bin/sh = bash (remove bashism)

PS: why `MAILTO=""` ? doesn't that disable whole cron definition mailing?

imho errors, like can't execute file, etc should be still mailed to root and therefore maybe the definition should be "tanto > /dev/null".