### PR TITLE
Check login length to determine if smtp login should be done

### DIFF
--- a/monitoring_agent/outputs/email.py
+++ b/monitoring_agent/outputs/email.py
@@ -79,7 +79,7 @@ class Email(object):
                 else:
                     smtp_server = smtplib.SMTP(self.servers[server]['host'], self.servers[server]['port'])
 
-                if self.servers[server]['login']:
+                if self.servers[server]['login'] and len(self.servers[server]['login']) > 0:
                     smtp_server.login(self.servers[server]['login'], self.servers[server]['password'])
                 smtp_server.sendmail(self.servers[server]['from'], self.servers[server]['to'], msg.as_string())
                 smtp_server.quit()


### PR DESCRIPTION
Without this check any value I tried resulted into trying to authenticate:

- Not specifying a value resulted in an error while reading the config file
- With an empty "login=" it still tried to authenticate
- Also with "login=False"
- Or with "login=None"
