### PR TITLE
Ws shinken

### DIFF
--- a/monitoring_agent/outputs/ws_shinken.py
+++ b/monitoring_agent/outputs/ws_shinken.py
@@ -51,7 +51,7 @@ class WsShinken(object):
         '''
         Constructor
         '''
-        self.http_headers = {'content-type': 'application/json', 'accept': 'application/json'}
+        self.http_headers = {'content-type': 'application/x-www-form-urlencoded', 'accept': '*/*'}
         # Setup servers dict
         self.servers = configurator.read(config_file,
                                          configspec='outputs/configspecs/ws_shinken.cfg',

--- a/tanto
+++ b/tanto
@@ -82,7 +82,8 @@ if __name__ == '__main__':
                                                        np_result['output'],
                                                        np_result['service_description'],
                                                        np_result['specific_servers'])
-                            CONFIG['ws_shinken'].send_result(np_result['output'],
+                            CONFIG['ws_shinken'].send_result(np_result['return_code'],
+                                                             np_result['output'],
                                                              np_result['service_description'],
                                                              np_result['time_stamp'],
                                                              np_result['specific_servers'])


### PR DESCRIPTION
Fixes #2 

- Wrong headers where used, resulting in failure to parse arguments
- Result code was not passed to ws_shinken output